### PR TITLE
[Feat/user nickname update] 사용자 정보 수정

### DIFF
--- a/src/main/java/org/project/monewping/domain/user/controller/UserController.java
+++ b/src/main/java/org/project/monewping/domain/user/controller/UserController.java
@@ -2,11 +2,14 @@ package org.project.monewping.domain.user.controller;
 
 import org.project.monewping.domain.user.dto.request.LoginRequest;
 import org.project.monewping.domain.user.dto.request.UserRegisterRequest;
+import org.project.monewping.domain.user.dto.request.UserNicknameUpdateRequest;
 import org.project.monewping.domain.user.dto.response.LoginResponse;
 import org.project.monewping.domain.user.dto.response.UserRegisterResponse;
 import org.project.monewping.domain.user.service.UserService;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -15,7 +18,7 @@ import org.springframework.web.bind.annotation.RestController;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 
-import java.util.Map;
+import java.util.UUID;
 
 /**
  * 사용자 관련 API를 처리하는 REST 컨트롤러
@@ -82,6 +85,14 @@ public class UserController {
     @PostMapping("/login")
     public ResponseEntity<LoginResponse> login(@Valid @RequestBody LoginRequest request) {
         LoginResponse response = userService.login(request);
+        return ResponseEntity.ok(response);
+    }
+
+    @PatchMapping("/{userId}")
+    public ResponseEntity<UserRegisterResponse> updateNickname(
+            @PathVariable("userId") String userId,
+            @Valid @RequestBody UserNicknameUpdateRequest request) {
+        UserRegisterResponse response = userService.updateNickname(UUID.fromString(userId), request);
         return ResponseEntity.ok(response);
     }
 }

--- a/src/main/java/org/project/monewping/domain/user/domain/User.java
+++ b/src/main/java/org/project/monewping/domain/user/domain/User.java
@@ -38,4 +38,8 @@ public class User extends BaseUpdatableEntity {
 
     @Column(name = "password", nullable = false, length = 100)
     private String password;
+
+    public void setNickname(String nickname) {
+        this.nickname = nickname;
+    }
 }

--- a/src/main/java/org/project/monewping/domain/user/dto/request/UserNicknameUpdateRequest.java
+++ b/src/main/java/org/project/monewping/domain/user/dto/request/UserNicknameUpdateRequest.java
@@ -1,0 +1,10 @@
+package org.project.monewping.domain.user.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+public record UserNicknameUpdateRequest(
+  @NotBlank(message = "닉네임은 필수입니다.")
+  @Size(min = 1, max = 50, message = "닉네임은 1자 이상 50자 이하로 입력해주세요.")
+  String nickname
+) {} 

--- a/src/main/java/org/project/monewping/domain/user/service/UserService.java
+++ b/src/main/java/org/project/monewping/domain/user/service/UserService.java
@@ -3,6 +3,7 @@ package org.project.monewping.domain.user.service;
 import org.project.monewping.domain.user.domain.User;
 import org.project.monewping.domain.user.dto.request.LoginRequest;
 import org.project.monewping.domain.user.dto.request.UserRegisterRequest;
+import org.project.monewping.domain.user.dto.request.UserNicknameUpdateRequest;
 import org.project.monewping.domain.user.dto.response.LoginResponse;
 import org.project.monewping.domain.user.dto.response.UserRegisterResponse;
 import org.project.monewping.domain.user.mapper.UserMapper;
@@ -10,6 +11,8 @@ import org.project.monewping.domain.user.repository.UserRepository;
 import org.project.monewping.domain.useractivity.service.UserActivityService;
 import org.project.monewping.global.exception.EmailAlreadyExistsException;
 import org.project.monewping.global.exception.LoginFailedException;
+import org.project.monewping.global.exception.GlobalExceptionHandler;
+import org.project.monewping.domain.user.exception.UserNotFoundException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -17,6 +20,8 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
 import java.time.Instant;
+import java.util.UUID;
+import java.util.Optional;
 
 /**
  * 사용자 관련 비즈니스 로직을 처리하는 서비스 클래스
@@ -155,5 +160,22 @@ public class UserService {
         if (userRepository.existsByEmail(email)) {
             throw new EmailAlreadyExistsException("이미 존재하는 이메일입니다.");
         }
+    }
+
+    /**
+     * 사용자 닉네임을 업데이트합니다.
+     * 
+     * @param userId 업데이트할 사용자 ID
+     * @param request 닉네임 업데이트 요청 정보
+     * @return 업데이트된 사용자 정보
+     * @throws IllegalArgumentException 존재하지 않는 사용자 ID인 경우
+     */
+    @Transactional
+    public UserRegisterResponse updateNickname(UUID userId, UserNicknameUpdateRequest request) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new UserNotFoundException("존재하지 않는 사용자입니다."));
+        user.setNickname(request.nickname());
+        User savedUser = userRepository.save(user);
+        return userMapper.toResponse(savedUser);
     }
 }

--- a/src/main/java/org/project/monewping/domain/user/service/UserService.java
+++ b/src/main/java/org/project/monewping/domain/user/service/UserService.java
@@ -176,6 +176,16 @@ public class UserService {
                 .orElseThrow(() -> new UserNotFoundException("존재하지 않는 사용자입니다."));
         user.setNickname(request.nickname());
         User savedUser = userRepository.save(user);
+        
+        // MongoDB 사용자 활동 내역도 함께 업데이트
+        try {
+            userActivityService.updateUserNickname(userId, request.nickname());
+            log.info("사용자 활동 내역 닉네임 업데이트 완료: userId={}, newNickname={}", userId, request.nickname());
+        } catch (Exception e) {
+            log.error("사용자 활동 내역 닉네임 업데이트 실패: userId={}, error={}", userId, e.getMessage());
+            // MongoDB 업데이트 실패가 PostgreSQL 업데이트를 실패시키지 않도록 예외를 잡아서 로그만 남김
+        }
+        
         return userMapper.toResponse(savedUser);
     }
 }

--- a/src/main/java/org/project/monewping/domain/useractivity/service/UserActivityService.java
+++ b/src/main/java/org/project/monewping/domain/useractivity/service/UserActivityService.java
@@ -49,6 +49,14 @@ public interface UserActivityService {
      */
     void deleteUserActivity(UUID userId);
 
+    /**
+     * 사용자 닉네임을 활동내역에 업데이트합니다.
+     * 
+     * @param userId 사용자 ID
+     * @param newNickname 새로운 닉네임
+     */
+    void updateUserNickname(UUID userId, String newNickname);
+
     // ========== 구독 관련 메서드 ==========
 
     /**

--- a/src/main/java/org/project/monewping/domain/useractivity/service/UserActivityServiceImpl.java
+++ b/src/main/java/org/project/monewping/domain/useractivity/service/UserActivityServiceImpl.java
@@ -96,6 +96,25 @@ public class UserActivityServiceImpl implements UserActivityService {
         log.debug("사용자 활동 내역 삭제 완료. userId: {}", userId);
     }
 
+    @Override
+    @Transactional
+    public void updateUserNickname(UUID userId, String newNickname) {
+        log.debug("사용자 닉네임 업데이트 시작. userId: {}, newNickname: {}", userId, newNickname);
+
+        UserActivityDocument document = userActivityRepository.findByUserId(userId)
+                .orElseThrow(() -> new UserActivityNotFoundException(userId));
+
+        // 사용자 정보의 닉네임 업데이트
+        UserActivityDocument.UserInfo userInfo = document.getUser();
+        userInfo.setNickname(newNickname);
+        document.setUser(userInfo);
+        document.setUpdatedAt(Instant.now());
+
+        userActivityRepository.save(document);
+
+        log.debug("사용자 닉네임 업데이트 완료. userId: {}, newNickname: {}", userId, newNickname);
+    }
+
     // ========== 구독 관련 메서드 ==========
 
     @Override

--- a/src/test/java/org/project/monewping/domain/useractivity/controller/UserActivityControllerSliceTest.java
+++ b/src/test/java/org/project/monewping/domain/useractivity/controller/UserActivityControllerSliceTest.java
@@ -22,7 +22,7 @@ import org.project.monewping.domain.useractivity.exception.UserActivityNotFoundE
 import org.project.monewping.domain.useractivity.service.UserActivityService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 
@@ -41,7 +41,7 @@ class UserActivityControllerSliceTest {
     @Autowired
     private MockMvc mockMvc;
 
-    @MockBean
+    @MockitoBean
     private UserActivityService userActivityService;
 
     private UUID testUserId = UUID.fromString("123e4567-e89b-12d3-a456-426614174000");


### PR DESCRIPTION
## #️⃣ Issue Number
<!-- ex) #이슈번호, #이슈번호 -->
Closes #3 
## 📝 요약(Summary)
<!-- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->
사용자 닉네임 수정 기능을 구현했습니다. 사용자는 PATCH /api/users/{userId} 엔드포인트를 통해 닉네임을 수정할 수 있으며, PostgreSQL의 users 테이블과 MongoDB의 사용자 활동 내역이 모두 최신화됩니다.

## 🛠️ PR 변경 사항
<-- 어떤 변경 사항이 있나요? -->

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경 등)
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [x] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 또는 설정 파일 수정
- [ ] 파일 또는 패키지 삭제

### 주요 변경사항:

#### 1. DTO 및 엔티티
- `UserNicknameUpdateRequest` record 생성 (닉네임 유효성 검증 포함)
- `User` 엔티티에 `setNickname()` 메서드 추가

#### 2. 서비스 로직
- `UserService.updateNickname()` 메서드 구현
- `UserActivityService.updateUserNickname()` 메서드 추가 (MongoDB 동기화)
- PostgreSQL과 MongoDB 트랜잭션 분리 처리

#### 3. API 엔드포인트
- `UserController`에 `PATCH /api/users/{userId}` 엔드포인트 추가

#### 4. 예외 처리
- `UserNotFoundException` 적용으로 404 응답 처리

#### 5. 테스트 코드
- 단위 테스트: `UserServiceTest` (정상/예외 케이스)
- 슬라이스 테스트: `UserControllerSliceTest` (HTTP 요청/응답 검증)
- 통합 테스트: `UserIntegrationTest` (DB 연동 end-to-end 검증)

## 📸스크린샷 (선택)
<!-- 리뷰어가 중점적으로 봐줬으면 좋겠는 부분이 있으면 적어주세요. -->
수정 이전
<img width="1054" height="574" alt="image" src="https://github.com/user-attachments/assets/ea8060b4-167d-468f-a0f7-f44f0c0e4208" />

수정 후
<img width="1090" height="534" alt="image" src="https://github.com/user-attachments/assets/ebc2cfcb-3b54-46a9-8788-e366b0bcab42" />


## 💬 공유사항
### 중점적으로 봐주시면 좋겠는 부분:
**트랜잭션 분리 설계**: PostgreSQL 업데이트 성공 후 MongoDB 업데이트 실패 시에도 PostgreSQL 변경사항이 유지되도록 try-catch로 처리했습니다.

### 논의사항:
- 현재 MongoDB 업데이트 실패 시 PostgreSQL 변경사항을 유지하는 설계로 했는데, 이 방식이 적절한지 검토 부탁드립니다.
- 닉네임 중복 체크가 필요하다면 추가 구현이 필요한지 의견 부탁드립니다.

## ✅ PR Checklist

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트)
